### PR TITLE
Revert back to original token expiration value

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ The Kubernetes token expiration should be shorter than the temporary STS
 credentials to avoid unexpected rejections.
 Role chaining limits your AWS CLI or AWS API role session to a maximum of one hour!!!
 """
-DEFAULT_EXPIRATION_SECONDS = 3500
+DEFAULT_EXPIRATION_SECONDS = 900
 
 EXPIRATION_BUFFER_SECONDS = 30
 


### PR DESCRIPTION
Unfortunately, only S3 has a configurable `X-Amz-Expires` header value. In our case the STS action `getCallerIdentity` cannot change the value. It is hardcoded to 15 minutes. 😢 

https://stackoverflow.com/a/66961500

[DO-1263](https://twisto.myjetbrains.com/youtrack/issue/DO-1263) Resolve TS token expiration issues